### PR TITLE
Fix bug where slider step value changed the max value instead

### DIFF
--- a/src/widgets/WidgetSlider.tsx
+++ b/src/widgets/WidgetSlider.tsx
@@ -170,7 +170,7 @@ const Editor = ({ props, onPropsChange }: WidgetEditorProps<PropsType>) => {
             onChange={(v) =>
               onPropsChange({
                 ...props,
-                max: Number.isFinite(v) ? v : propsSchema.shape.step.def.defaultValue,
+                step: Number.isFinite(v) ? v : propsSchema.shape.step.def.defaultValue,
               })
             }
           />


### PR DESCRIPTION
This fixes the bug where the slider step value changes the max instead. This also resolves the [issue](https://github.com/2702rebels/reflect/issues/3) I created.