### PR TITLE
Add the ability to make sliders vertical

### DIFF
--- a/src/components/slider.tsx
+++ b/src/components/slider.tsx
@@ -3,15 +3,32 @@ import { memo } from "react";
 
 import { cn } from "../lib/utils";
 
-export const Slider = memo(({ className, ...props }: React.ComponentProps<typeof SliderPrimitive.Root>) => (
-  <SliderPrimitive.Root
-    className={cn("relative flex w-full touch-none items-center select-none", className)}
-    {...props}>
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-slate-700">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-));
+export const Slider = memo(({ className, ...props }: React.ComponentProps<typeof SliderPrimitive.Root>) => {
+  const vertical = props.orientation === "vertical";
+
+  const rootClass = cn(
+    vertical
+      ? "relative flex h-full touch-none select-none flex-col items-center"
+      : "relative flex w-full touch-none items-center select-none",
+    className
+  );
+
+  const trackClass = cn(
+    vertical
+      ? "relative w-2 h-full grow overflow-hidden rounded-full bg-slate-700"
+      : "relative h-2 w-full grow overflow-hidden rounded-full bg-slate-700"
+  );
+
+  const rangeClass = vertical ? "absolute w-full bg-primary bottom-0" : "absolute h-full bg-primary";
+
+  return (
+    <SliderPrimitive.Root className={rootClass} {...props}>
+      <SliderPrimitive.Track className={trackClass}>
+        <SliderPrimitive.Range className={rangeClass} />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  );
+});
 
 Slider.displayName = "Slider";

--- a/src/components/slider.tsx
+++ b/src/components/slider.tsx
@@ -3,32 +3,18 @@ import { memo } from "react";
 
 import { cn } from "../lib/utils";
 
-export const Slider = memo(({ className, ...props }: React.ComponentProps<typeof SliderPrimitive.Root>) => {
-  const vertical = props.orientation === "vertical";
-
-  const rootClass = cn(
-    vertical
-      ? "relative flex h-full touch-none select-none flex-col items-center"
-      : "relative flex w-full touch-none items-center select-none",
-    className
-  );
-
-  const trackClass = cn(
-    vertical
-      ? "relative w-2 h-full grow overflow-hidden rounded-full bg-slate-700"
-      : "relative h-2 w-full grow overflow-hidden rounded-full bg-slate-700"
-  );
-
-  const rangeClass = vertical ? "absolute w-full bg-primary bottom-0" : "absolute h-full bg-primary";
-
-  return (
-    <SliderPrimitive.Root className={rootClass} {...props}>
-      <SliderPrimitive.Track className={trackClass}>
-        <SliderPrimitive.Range className={rangeClass} />
-      </SliderPrimitive.Track>
-      <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
-    </SliderPrimitive.Root>
-  );
-});
+export const Slider = memo(({ className, ...props }: React.ComponentProps<typeof SliderPrimitive.Root>) => (
+  <SliderPrimitive.Root
+    className={cn(
+      "relative flex touch-none items-center select-none data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:flex-col",
+      className
+    )}
+    {...props}>
+    <SliderPrimitive.Track className="relative grow overflow-hidden rounded-full bg-slate-700 data-[orientation=horizontal]:h-2 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2">
+      <SliderPrimitive.Range className="absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:w-full" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
 
 Slider.displayName = "Slider";

--- a/src/widgets/WidgetSlider.tsx
+++ b/src/widgets/WidgetSlider.tsx
@@ -80,45 +80,17 @@ const Component = ({ mode, slot, data, props, publish }: WidgetComponentProps<Pr
         </div>
       </div>
       {d != null && (
-        // render either vertical or horizontal layout depending on prop
-        (vertical === true) ? (
-          <div
-            className={cn(
-              "mx-3 my-1 flex flex-auto flex-row items-center justify-center gap-4",
-              preview && "opacity-25"
-            )}
-          >
-            <div className="flex flex-col justify-between h-full">
-              <TruncateText className="font-mono text-xs">
-                {Format.default.number(props.max, {
-                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
-                })}
-              </TruncateText>
-              <TruncateText className="font-mono text-xs">
-                {Format.default.number(props.min, {
-                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
-                })}
-              </TruncateText>
-            </div>
-
-            <div className="flex h-full items-center">
-              <Slider
-                aria-label="Value"
-                orientation="vertical"
-                value={[d]}
-                disabled={!interactive}
-                onValueChange={interactive ? handleChange : undefined}
-                min={props.min}
-                max={props.max}
-                step={props.step}
-                className="h-full"
-              />
-            </div>
-          </div>
-        ) : (
-          <div className={cn("mx-3 my-1 flex flex-auto flex-col justify-center gap-2", preview && "opacity-25")}>
+        <div
+          className={cn(
+            "mx-3 my-1 flex flex-auto justify-center gap-2",
+            preview && "opacity-25",
+            props.vertical && "flex-row items-center",
+            !props.vertical && "flex-col"
+          )}>
+          <div className={cn("flex items-center", props.vertical && "h-full", !props.vertical && "w-full")}>
             <Slider
               aria-label="Value"
+              orientation={props.vertical ? "vertical" : "horizontal"}
               value={[d]}
               disabled={!interactive}
               onValueChange={interactive ? handleChange : undefined}
@@ -126,20 +98,25 @@ const Component = ({ mode, slot, data, props, publish }: WidgetComponentProps<Pr
               max={props.max}
               step={props.step}
             />
-            <div className="flex justify-between">
-              <TruncateText className="font-mono text-xs">
-                {Format.default.number(props.min, {
-                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
-                })}
-              </TruncateText>
-              <TruncateText className="font-mono text-xs">
-                {Format.default.number(props.max, {
-                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
-                })}
-              </TruncateText>
-            </div>
           </div>
-        )
+          <div
+            className={cn(
+              "flex justify-between",
+              props.vertical && "h-full flex-col",
+              !props.vertical && "w-full flex-row"
+            )}>
+            <TruncateText className="font-mono text-xs">
+              {Format.default.number(props.vertical ? props.max : props.min, {
+                maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
+              })}
+            </TruncateText>
+            <TruncateText className="font-mono text-xs">
+              {Format.default.number(props.vertical ? props.min : props.max, {
+                maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
+              })}
+            </TruncateText>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/widgets/WidgetSlider.tsx
+++ b/src/widgets/WidgetSlider.tsx
@@ -27,6 +27,8 @@ const numericFormat = z.object({
 const propsSchema = z.object({
   title: z.string().optional(),
   interactive: z.boolean().optional(),
+  // when true the slider will be rendered vertically
+  vertical: z.boolean().default(false),
   valueFormat: numericFormat.optional(),
   min: z.number().default(-1),
   max: z.number().default(1),
@@ -46,6 +48,7 @@ const transform = (dataType: DataType, records: ReadonlyArray<DataChannelRecord>
 
 const Component = ({ mode, slot, data, props, publish }: WidgetComponentProps<PropsType>) => {
   const interactive = props.interactive;
+  const vertical = props.vertical;
   const handleChange = useCallback(
     (v: Array<number>) => {
       if (interactive && publish) {
@@ -78,29 +81,66 @@ const Component = ({ mode, slot, data, props, publish }: WidgetComponentProps<Pr
         </div>
       </div>
       {d != null && (
-        <div className={cn("mx-3 my-1 flex flex-auto flex-col justify-center gap-2", preview && "opacity-25")}>
-          <Slider
-            aria-label="Value"
-            value={[d]}
-            disabled={!interactive}
-            onValueChange={interactive ? handleChange : undefined}
-            min={props.min}
-            max={props.max}
-            step={props.step}
-          />
-          <div className="flex justify-between">
-            <TruncateText className="font-mono text-xs">
-              {Format.default.number(props.min, {
-                maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
-              })}
-            </TruncateText>
-            <TruncateText className="font-mono text-xs">
-              {Format.default.number(props.max, {
-                maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
-              })}
-            </TruncateText>
+        // render either vertical or horizontal layout depending on prop
+        (vertical && vertical === true) ? (
+          <div
+            className={cn(
+              "mx-3 my-1 flex flex-auto flex-row items-center justify-center gap-4",
+              preview && "opacity-25"
+            )}
+          >
+            <div className="flex flex-col justify-between h-full">
+              <TruncateText className="font-mono text-xs">
+                {Format.default.number(props.max, {
+                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
+                })}
+              </TruncateText>
+              <TruncateText className="font-mono text-xs">
+                {Format.default.number(props.min, {
+                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
+                })}
+              </TruncateText>
+            </div>
+
+            <div className="flex h-full items-center">
+              <Slider
+                aria-label="Value"
+                orientation="vertical"
+                value={[d]}
+                disabled={!interactive}
+                onValueChange={interactive ? handleChange : undefined}
+                min={props.min}
+                max={props.max}
+                step={props.step}
+                className="h-full"
+              />
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className={cn("mx-3 my-1 flex flex-auto flex-col justify-center gap-2", preview && "opacity-25")}>
+            <Slider
+              aria-label="Value"
+              value={[d]}
+              disabled={!interactive}
+              onValueChange={interactive ? handleChange : undefined}
+              min={props.min}
+              max={props.max}
+              step={props.step}
+            />
+            <div className="flex justify-between">
+              <TruncateText className="font-mono text-xs">
+                {Format.default.number(props.min, {
+                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
+                })}
+              </TruncateText>
+              <TruncateText className="font-mono text-xs">
+                {Format.default.number(props.max, {
+                  maximumFractionDigits: props.valueFormat?.maximumFractionDigits,
+                })}
+              </TruncateText>
+            </div>
+          </div>
+        )
       )}
     </div>
   );
@@ -128,6 +168,16 @@ const Editor = ({ props, onPropsChange }: WidgetEditorProps<PropsType>) => {
           onPropsChange({
             ...props,
             interactive: v,
+          })
+        }
+      />
+      <EditorSwitchBlock
+        label="Vertical"
+        checked={props.vertical}
+        onCheckedChange={(v) =>
+          onPropsChange({
+            ...props,
+            vertical: v,
           })
         }
       />
@@ -221,6 +271,7 @@ export const WidgetSliderDescriptor: WidgetDescriptor<PropsType> = {
     schema: propsSchema,
     defaultValue: {
       interactive: false,
+      vertical: false,
       min: propsSchema.shape.min.def.defaultValue,
       max: propsSchema.shape.max.def.defaultValue,
       step: propsSchema.shape.step.def.defaultValue,

--- a/src/widgets/WidgetSlider.tsx
+++ b/src/widgets/WidgetSlider.tsx
@@ -84,10 +84,9 @@ const Component = ({ mode, slot, data, props, publish }: WidgetComponentProps<Pr
           className={cn(
             "mx-3 my-1 flex flex-auto justify-center gap-2",
             preview && "opacity-25",
-            props.vertical && "flex-row items-center",
-            !props.vertical && "flex-col"
+            props.vertical ? "flex-row items-center" : "flex-col"
           )}>
-          <div className={cn("flex items-center", props.vertical && "h-full", !props.vertical && "w-full")}>
+          <div className={cn("flex items-center", props.vertical ? "h-full" : "w-full")}>
             <Slider
               aria-label="Value"
               orientation={props.vertical ? "vertical" : "horizontal"}
@@ -99,12 +98,7 @@ const Component = ({ mode, slot, data, props, publish }: WidgetComponentProps<Pr
               step={props.step}
             />
           </div>
-          <div
-            className={cn(
-              "flex justify-between",
-              props.vertical && "h-full flex-col",
-              !props.vertical && "w-full flex-row"
-            )}>
+          <div className={cn("flex justify-between", props.vertical ? "h-full flex-col" : "w-full flex-row")}>
             <TruncateText className="font-mono text-xs">
               {Format.default.number(props.vertical ? props.max : props.min, {
                 maximumFractionDigits: props.valueFormat?.maximumFractionDigits,

--- a/src/widgets/WidgetSlider.tsx
+++ b/src/widgets/WidgetSlider.tsx
@@ -27,7 +27,6 @@ const numericFormat = z.object({
 const propsSchema = z.object({
   title: z.string().optional(),
   interactive: z.boolean().optional(),
-  // when true the slider will be rendered vertically
   vertical: z.boolean().default(false),
   valueFormat: numericFormat.optional(),
   min: z.number().default(-1),
@@ -82,7 +81,7 @@ const Component = ({ mode, slot, data, props, publish }: WidgetComponentProps<Pr
       </div>
       {d != null && (
         // render either vertical or horizontal layout depending on prop
-        (vertical && vertical === true) ? (
+        (vertical === true) ? (
           <div
             className={cn(
               "mx-3 my-1 flex flex-auto flex-row items-center justify-center gap-4",


### PR DESCRIPTION
Added an option in the slider settings to make the slider vertical. This addresses the [feature request](https://github.com/2702rebels/reflect/issues/2) I created.
![VerticalSliders](https://github.com/user-attachments/assets/bbb05839-79e6-4430-a2d5-1a88650db585)