### PR TITLE
Tree nodes default to collapsed state, making navigation easier

### DIFF
--- a/src/components/tree.tsx
+++ b/src/components/tree.tsx
@@ -87,7 +87,7 @@ const TreeItem = <T,>({
             <AccordionPrimitive.Root
               type="single"
               collapsible
-              defaultValue={d.id}>
+              >
               <AccordionPrimitive.Item value={d.id}>
                 <AccordionTrigger
                   className="p-2 before:absolute before:left-0 before:-z-10 before:h-9 before:w-full before:bg-muted/80 before:opacity-0 hover:before:opacity-100 data-[selected='true']:text-accent-foreground data-[selected='true']:before:border-l-2 data-[selected='true']:before:border-l-accent-foreground/60 data-[selected='true']:before:bg-accent/80 data-[selected='true']:before:opacity-100"


### PR DESCRIPTION
Changed the `tree.tsx` component to make the drop downs default to collapsed, making it easier to find the variable you are looking for without scrolling very far.

<img width="628" height="245" alt="Screenshot 2026-02-05 at 17 54 29" src="https://github.com/user-attachments/assets/53368a6b-1eb5-405a-9f89-eb49e3577e9b" />
